### PR TITLE
Fix/gaia testing script

### DIFF
--- a/deploy/gaia_test.js
+++ b/deploy/gaia_test.js
@@ -2,8 +2,9 @@
  * This script will test your GAIA hub by connecting to it,
  * uploading a test file and then downloading it.
  * It requieres a GAIA Hub URL as input to test.
- * Usage from the command line is: node gaia_test https://yourgaiadomian.com
+ * Usage from the command line is: node gaia_test.js https://yourgaiadomain.com
  */
+
 //Import required dependencies
 const { makeECPrivateKey, getPublicKeyFromPrivate, publicKeyToAddress } = require('@stacks/encryption');
 const { connectToGaiaHub, uploadToGaiaHub } = require('@stacks/storage');

--- a/deploy/gaia_test.js
+++ b/deploy/gaia_test.js
@@ -1,3 +1,9 @@
+/*
+ * This script will test your GAIA hub by connecting to it,
+ * uploading a test file and then downloading it.
+ * It requieres a GAIA Hub URL as input to test.
+ * Usage from the command line is: node gaia_test https://yourgaiadomian.com
+ */
 //Import required dependencies
 const { makeECPrivateKey, getPublicKeyFromPrivate, publicKeyToAddress } = require('@stacks/encryption');
 const { connectToGaiaHub, uploadToGaiaHub } = require('@stacks/storage');

--- a/deploy/gaia_test.js
+++ b/deploy/gaia_test.js
@@ -1,19 +1,40 @@
-const bsk = require('blockstack')
-const privateKey = bsk.makeECPrivateKey()
-const publicKey = bsk.getPublicKeyFromPrivate(privateKey)
-const address = bsk.publicKeyToAddress(publicKey)
+//Import required dependencies
+const { makeECPrivateKey, getPublicKeyFromPrivate, publicKeyToAddress } = require('@stacks/encryption');
+const { connectToGaiaHub, uploadToGaiaHub } = require('@stacks/storage');
 
-const hubUrl = 'https://gaia.stacks.co'
+//Set my GAIA HUB domain
+const args = process.argv.slice(2); //Get domain to test from the command line
+const myDomain = args[0];
+if(myDomain == undefined) {
+  console.log(`No domain defined.`);
+  console.log(`To run the test, please type a valid GAIA HUB: "node gaia_test https://yourgaiadomain.com"`);
+  process.exit();
+}
+else {
+  console.log('Will run a test for the GAIA HUB:',myDomain); 
+}
 
-bsk.connectToGaiaHub(hubUrl, privateKey)
+//Generate my privateKey, publicKey and address
+console.log(`Generating some test keys...`);
+const privateKey = makeECPrivateKey();
+const publicKey = getPublicKeyFromPrivate(privateKey);
+const address = publicKeyToAddress(publicKey);
+console.log('Private key: ',privateKey);
+console.log('Public key:  ',publicKey);
+console.log('Address:     ',address);
+
+//Connect to my GAIA hub using my privateKey
+  connectToGaiaHub(myDomain, privateKey)
   .then((hubConfig) => {
-    return bsk.uploadToGaiaHub('foo.txt', 'hello world!', hubConfig)
+      //Upload a test file
+      return uploadToGaiaHub('testing.txt', 'GAIA ROCKS!', hubConfig)
       .then((writtenFile) => {
-        console.log(`Upload to gaia hub thinks it can read from: ${writtenFile}`)
-        console.log(`Hub info thinks it can read from: ${hubConfig.url_prefix}${hubConfig.address}/foo.txt`)
-        return fetch(`${hubConfig.url_prefix}${hubConfig.address}/foo.txt`)
-          .then(resp => resp.text())
-          .then(x => console.log(`Contents of file: ${x}`))
+          console.log(`File uploaded successfully.`);
+          console.log(`Upload to gaia hub thinks it can read it from: ${writtenFile.publicURL}`);
+          console.log(`Hub info thinks it can read it from          : ${hubConfig.url_prefix}${hubConfig.address}/testing.txt`);
+          console.log(`Let's now try to fetch the uploaded file...`);
+          return fetch(`${hubConfig.url_prefix}${hubConfig.address}/testing.txt`)
+            .then(resp => resp.text())
+            .then(x => console.log(`File fetched successfully. Contents of file: ${x}`))
       })
   })
-


### PR DESCRIPTION
The current test script `gaia_test.js` does'nt work anymore. This PR replaces it with a new one that does exactly the same thing as the older one used to. It connects to a GAIA Hub, uploads a test file and then download it again.

Usage is `node gaia_test.js https://mygaiahub.com`
If you try to execute it without a parameter, like `node gaia_test.js` some instructions will display asking the user for the URL.

##@ Examples or runtime
Example of missing parameter output:
```
$ node gaia_test.js
No domain defined.
To run the test, please type a valid GAIA HUB: "node gaia_test.js https://yourgaiadomain.com"
```

Example of correct output:
```
$ node gaia_test.js https://gaia.mydomain.com
Will run a test for the GAIA HUB: https://gaia.mydomain.com
Generating some test keys...
Private key:  5aacc60fc2a429e1f02be139f3cac82061***********************************
Public key:   025691f17f2ab80dc4af363bb9c7aac59e9e1db6ae8ff668202582a3f4ec9678ff
Address:      15n8Xo8acRvSZghJG2dxJ8dCdzDMYicUuS
[DEBUG] connectToGaiaHub: https://gaia.mydomain.com/hub_info
[DEBUG] uploadToGaiaHub: uploading testing.txt to https://gaia.mydomain.com
File uploaded successfully.
Upload to gaia hub thinks it can read it from: https://gaia.mydomain.com/reader/15n8Xo8acRvSZghJG2dxJ8dCdzDMYicUuS/testing.txt
Hub info thinks it can read it from          : https://gaia.mydomain.com/reader/15n8Xo8acRvSZghJG2dxJ8dCdzDMYicUuS/testing.txt
Let's now try to fetch the uploaded file...
File fetched successfully. Contents of file: GAIA ROCKS!
```

Instructions to run this test are included in this other [PR](https://github.com/stacks-network/gaia/pull/365).