### PR TITLE
GAIA Cloudformation SSH access fix

### DIFF
--- a/deploy/cloudformation.yaml
+++ b/deploy/cloudformation.yaml
@@ -196,8 +196,7 @@ Resources:
         - IpProtocol: tcp
           FromPort: "22"
           ToPort: "22"
-          CidrIp:
-            Ref: SSHLocation
+          CidrIp: 0.0.0.0/0
         - IpProtocol: tcp
           FromPort: 80
           ToPort: 80


### PR DESCRIPTION
## Goal of PR

Updated the cloudformation template to avoid and SSH access problem [reported on the forum](https://forum.stacks.org/t/cors-issue-accessing-my-own-gaia-with-aws-cloud/13141)